### PR TITLE
goto-last-change: don't check buffer-undo-tree when not using undo-tree

### DIFF
--- a/goto-chg.el
+++ b/goto-chg.el
@@ -97,6 +97,8 @@
 
 ;;; Code:
 
+(require 'undo-tree nil t)
+
 (defvar glc-default-span 8 "*goto-last-change don't visit the same point twice. glc-default-span tells how far around a visited point not to visit again.")
 (defvar glc-current-span 8 "Internal for goto-last-change.\nA copy of glc-default-span or the ARG passed to goto-last-change.")
 (defvar glc-probe-depth 0 "Internal for goto-last-change.\nIt is non-zero between successive goto-last-change.")
@@ -268,7 +270,9 @@ discarded. See variable `undo-limit'."
                glc-current-span glc-default-span)
          (if (< (prefix-numeric-value arg) 0)
              (error "Negative arg: Cannot reverse as the first operation"))))
-  (cond ((and (null buffer-undo-list) (null buffer-undo-tree))
+  (cond ((and (null buffer-undo-list)
+              (or (not (boundp 'buffer-undo-tree))
+                  (null buffer-undo-tree)))
          (error "Buffer has not been changed"))
         ((eq buffer-undo-list t)
          (error "No change info (undo is disabled)")))

--- a/goto-chg.el
+++ b/goto-chg.el
@@ -231,11 +231,10 @@ Return nil if E represents no real change.
 that is, it was previously saved or unchanged. Nil otherwise."
   (and (listp e) (eq (car e) t)))
 
-(declare-function undo-tree-current "undo-tree")
-(declare-function undo-tree-node-p "undo-tree")
-(declare-function undo-tree-node-previous "undo-tree")
-(declare-function undo-tree-node-undo "undo-tree")
-(declare-function undo-list-transfer-to-tree "undo-tree")
+(declare-function undo-tree-current "ext:undo-tree")
+(declare-function undo-tree-node-previous "ext:undo-tree")
+(declare-function undo-tree-node-undo "ext:undo-tree")
+(declare-function undo-list-transfer-to-tree "ext:undo-tree")
 (defvar buffer-undo-tree)
 
 ;;;###autoload
@@ -335,7 +334,7 @@ discarded. See variable `undo-limit'."
             (when (not glc-seen-canary)
               (setq l (cdr l)))))
         (when glc-seen-canary
-          (while (and (< n new-probe-depth) (undo-tree-node-p l))
+          (while (and (< n new-probe-depth) (eval '(undo-tree-node-p l)))
             (cond ((null l)
                    ;(setq this-command t)	; Disrupt repeat sequence
                    (error "No further change info"))


### PR DESCRIPTION
If undo-tree is not loaded, we get a void-variable error when checking buffer-undo-tree.

Also fix `declare-function` invocations: per the documentation for `declare-function`, external Elisp libraries
should have 'ext:' in front.

To be safe, optionally `require` `undo-tree` to avoid undefined-function errors.

Finally, avoid byte-compiling the invocation of the macro `undo-tree-node-p` since that confuses the byte-compiler unless we make `undo-tree` a hard dependency.