### PR TITLE
Add lexical binding directive

### DIFF
--- a/goto-chg.el
+++ b/goto-chg.el
@@ -1,4 +1,4 @@
-;;; goto-chg.el --- Go to last change
+;;; goto-chg.el --- Go to last change -*- lexical-binding: t -*-
 ;;--------------------------------------------------------------------
 ;;
 ;; Copyright (C) 2002-2008,2013 David Andersson


### PR DESCRIPTION
Fixes a warning:

      ⛔ Warning (comp): ~/.emacs.d/elpa/goto-chg-20220107.1733/goto-chg.el:1:1: Warning: file has no ‘lexical-binding’ directive on its first line